### PR TITLE
Rename diags

### DIFF
--- a/Training/observer_abilities.py
+++ b/Training/observer_abilities.py
@@ -40,11 +40,11 @@ class Observer(object):
 
     def scan_diags(self, board):
         analyzed_diags = []
-        analyzed_diags.append(self.scan_NW_SE(board))
-        analyzed_diags.append(self.scan_NE_SW(board))
+        analyzed_diags.append(self.scan_1st_diag(board))
+        analyzed_diags.append(self.scan_2nd_diag(board))
         return analyzed_diags
 
-    def scan_NW_SE(self, board):
+    def scan_1st_diag(self, board):
         value = 0
         board_size = self.get_board_size(board)
         target_index = 0
@@ -53,7 +53,7 @@ class Observer(object):
             target_index += board_size + 1
         return value
 
-    def scan_NE_SW(self, board):
+    def scan_2nd_diag(self, board):
         value = 0
         board_size = self.get_board_size(board)
         target_index = board_size - 1

--- a/tests/test_observer_abilities.py
+++ b/tests/test_observer_abilities.py
@@ -18,8 +18,8 @@ class ObserverTestCase(unittest.TestCase):
         self.expected_rows = [11,11,12]
         self.expected_cols = [3,20,11]
         self.expected_diags = [12,21]
-        self.expected_NW_SE_value = 12
-        self.expected_NE_SW_value = 21
+        self.expected_1st_value = 12
+        self.expected_2nd_value = 21
 
     def test_get_board_size_3(self):
         test = self.observer.get_board_size(self.mock_board)
@@ -49,13 +49,13 @@ class ObserverTestCase(unittest.TestCase):
         test_yields = self.observer.scan_diags(self.mock_board)
         self.assertEqual(test_yields, self.expected_diags)
 
-    def test_scan_NW_SE_diag_returns_analyzed_value(self):
-        test_yields = self.observer.scan_NW_SE(self.mock_board)
-        self.assertEqual(test_yields, self.expected_NW_SE_value)
+    def test_scan_first_diag_returns_analyzed_value(self):
+        test_yields = self.observer.scan_1st_diag(self.mock_board)
+        self.assertEqual(test_yields, self.expected_1st_value)
 
-    def test_scan_NE_SW_diag_returns_analyzed_value(self):
-        test_yields = self.observer.scan_NE_SW(self.mock_board)
-        self.assertEqual(test_yields, self.expected_NE_SW_value)
+    def test_scan_second_diag_returns_analyzed_value(self):
+        test_yields = self.observer.scan_2nd_diag(self.mock_board)
+        self.assertEqual(test_yields, self.expected_2nd_value)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
in Training.oberver_abilities, 
rename scan_NE_SW() and scan_SE_NW() to scan_1st_diag() and scan_2nd_diag()

this makes the naming clearer in context and avoids the use of initials. Does anyone really need to know the direction of the diagonals?