### PR TITLE
Refactor unnecessary assignments

### DIFF
--- a/OnStage/player_chair.py
+++ b/OnStage/player_chair.py
@@ -80,12 +80,11 @@ class Computer(Player):
         return choice
 
     def get_intelligence(self, board):
-        intel = { 'board': board, 
-                  'options': self.get_legal_moves(board),
-                  'analysis': self.scan_board(board),
-                  'marker_code': self.marker_code, 
-                  'enemy_code': self.get_enemy_code() }
-        return intel
+        return { 'board': board, 
+                 'options': self.get_legal_moves(board),
+                 'analysis': self.scan_board(board),
+                 'marker_code': self.marker_code, 
+                 'enemy_code': self.get_enemy_code() }
 
     def announce_choice(self, choice):
         pre = self.announcer.pre_choice

--- a/Training/cortex_3x3_caddy.py
+++ b/Training/cortex_3x3_caddy.py
@@ -7,12 +7,12 @@ class Cortex_3x3(object):
     tac = TacticalLobe()
 
     def direct_move(self, intel):
-        priority_list = self.ask_lobes(intel)
+        priority_list = self.get_priority_list(intel)
         for priority in priority_list:
             if priority is not False:
 	        return priority
 
-    def ask_lobes(self, intel):       
+    def get_priority_list(self, intel):       
         p1 = self.tac.take_win_chance(intel)
         p2 = self.tac.avoid_losing(intel)
         p3 = self.tac.take_fork_chance(intel)

--- a/Training/cortex_3x3_caddy.py
+++ b/Training/cortex_3x3_caddy.py
@@ -20,5 +20,4 @@ class Cortex_3x3(object):
         p5 = self.strat.take_the_center(intel)
         p6 = self.strat.take_catty_corner(intel)
         p7 = self.strat.make_default_choice(intel)
-        priority_list = [p1, p2, p3, p4, p5, p6, p7]
-        return priority_list
+        return [p1, p2, p3, p4, p5, p6, p7]

--- a/tests/test_cortex_3x3_caddy.py
+++ b/tests/test_cortex_3x3_caddy.py
@@ -13,8 +13,8 @@ class Cortex3x3TestCase(unittest.TestCase):
         self.priorities = [5,2,False,False,False,2,2]
 
 
-    def test_ask_lobes_returns_a_priority_list(self):
-        test_yields = self.cortex.ask_lobes(self.intel)
+    def test_get_priority_list_returns_a_priority_list(self):
+        test_yields = self.cortex.get_priority_list(self.intel)
         self.assertEqual(test_yields, self.priorities)
 
     def test_direct_move_returns_a_direction(self):


### PR DESCRIPTION
Changes `Training.cortex_3x3_caddy.ask_lobes()` to `get_priority_list()`.
This means that I don't have to include the assignment statement `priority_list = ...` because I no longer need it to comment on what the method is doing.

Also deletes the unnecessary assignment statement in `OnStage.computer.get_intelligence()`