### PR TITLE
Abstract raw_input and message from Human and Emcee; Fixes #35

### DIFF
--- a/BackStage/emcee_podium.py
+++ b/BackStage/emcee_podium.py
@@ -17,7 +17,7 @@ class Emcee(object):
            self.table_top.give_computer_the_first_move()
 
     def get_choice(self):
-        choice = self.ask_human()
+        choice = self.announcer.ask_human()
         if choice == '1' or choice == '2':
             return choice
         elif self.strikes == 2:

--- a/BackStage/emcee_podium.py
+++ b/BackStage/emcee_podium.py
@@ -35,6 +35,3 @@ class Emcee(object):
             return self.announcer.show(self.announcer.computer)
         elif winner == 'human':
             return self.announcer.show(self.announcer.human)
-
-    def ask_human(self):
-        return raw_input('> ')

--- a/OnStage/player_chair.py
+++ b/OnStage/player_chair.py
@@ -46,7 +46,7 @@ class Human(Player):
     def get_good_input(self, board):
         try:
             self.announcer.show(self.announcer.question)
-            return int(raw_input("> ")) -1
+            return int(self.announcer.ask_human()) -1
         except(ValueError):
             return self.redo_move(board)
 

--- a/tests/test_emcee_podium.py
+++ b/tests/test_emcee_podium.py
@@ -17,22 +17,17 @@ class MuteAnnouncerE(MuteAnnouncer1):
     def ask_human(self):
         return 'Ni'
 
-class Dummy(Emcee):
-    def __init__(self, board):
-        self.table_top = board
-        self.announcer = MuteAnnouncer1()
-
 class Mc_Human(Emcee):
     def __init__(self, board):
         self.table_top = board
         self.announcer = MuteAnnouncer1()
 
-class Mc_Computer(Dummy):
+class Mc_Computer(Mc_Human):
     def __init__(self, board):
         self.table_top = board
         self.announcer = MuteAnnouncer2()
 
-class Mc_Error(Dummy):
+class Mc_Error(Mc_Human):
      def __init__(self, board):
         self.table_top = board
         self.announcer = MuteAnnouncerE()   

--- a/tests/test_emcee_podium.py
+++ b/tests/test_emcee_podium.py
@@ -3,33 +3,45 @@ from BackStage.emcee_podium import *
 from Scenery.announcer_chair import *
 from OnStage.game_table import *
 
-class MuteAnnouncer(Announcer):
+class MuteAnnouncer1(Announcer):
     def show(self, what_is_said):
         return what_is_said
+    def ask_human(self):
+        return '1'
+
+class MuteAnnouncer2(MuteAnnouncer1):
+    def ask_human(self):
+        return '2'
+
+class MuteAnnouncerE(MuteAnnouncer1):
+    def ask_human(self):
+        return 'Ni'
 
 class Dummy(Emcee):
     def __init__(self, board):
         self.table_top = board
-        self.announcer = MuteAnnouncer()
+        self.announcer = MuteAnnouncer1()
 
-class Mc_Human(Dummy):
-    def ask_human(self):
-        return '1'
+class Mc_Human(Emcee):
+    def __init__(self, board):
+        self.table_top = board
+        self.announcer = MuteAnnouncer1()
 
 class Mc_Computer(Dummy):
-    def ask_human(self):
-        return '2'
+    def __init__(self, board):
+        self.table_top = board
+        self.announcer = MuteAnnouncer2()
 
 class Mc_Error(Dummy):
-    def ask_human(self):
-        return 'Ni!'
+     def __init__(self, board):
+        self.table_top = board
+        self.announcer = MuteAnnouncerE()   
 
 class EmceeTestCase(unittest.TestCase):
 
     def setUp(self):
         self.table_top = TableTop()
-        self.signer = MuteAnnouncer()
-        self.mc_dummy = Dummy(self.table_top)
+        self.signer = MuteAnnouncer1()
         self.mc_human = Mc_Human(self.table_top)
         self.mc_computer = Mc_Computer(self.table_top)
         self.mc_error = Mc_Error(self.table_top)
@@ -74,17 +86,17 @@ class EmceeTestCase(unittest.TestCase):
             self.mc_error.get_choice()
 
     def test_end_game_returns_the_tied_game(self):
-        test_yields = self.mc_dummy.end_game(self.tied_game)
+        test_yields = self.mc_human.end_game(self.tied_game)
         whats_expected = self.signer.show(self.signer.tie)
         self.assertEqual(test_yields, whats_expected)
 
     def test_end_game_returns_the_computer_win(self):
-        test_yields = self.mc_dummy.end_game(self.computer_win)
+        test_yields = self.mc_human.end_game(self.computer_win)
         whats_expected = self.signer.show(self.signer.computer)
         self.assertEqual(test_yields, whats_expected)
 
     def test_end_game_returns_the_human_win(self):
-        test_yields = self.mc_dummy.end_game(self.human_win)
+        test_yields = self.mc_human.end_game(self.human_win)
         whats_expected = self.signer.show(self.signer.human)
         self.assertEqual(test_yields, whats_expected)
 

--- a/tests/test_stage_manager_booth.py
+++ b/tests/test_stage_manager_booth.py
@@ -9,6 +9,8 @@ from OnStage.game_table import *
 class MuteAnnouncer(Announcer):
     def show(self, statement):
         return statement
+    def ask_human(self):
+        return '1'
 
 class DummyHuman(Player):
     name = 'human'


### PR DESCRIPTION
This should have been done earlier, but somehow got overlooked. 

All display strings should be in a single place, no straggling ">" prompts.

All calls to print and raw_input (which are command line specific) should be in one place, the announcer class.

this PR does both.